### PR TITLE
Fix: The written conditional expressions were opposite.

### DIFF
--- a/src/receivers/verify-request.ts
+++ b/src/receivers/verify-request.ts
@@ -82,7 +82,7 @@ export async function verify(
     )
 
     // TODO Time safe compare (?)
-    if (signatureHash === hmac.hex()) {
+    if (signatureHash !== hmac.hex()) {
         throw new Error(`${verifyErrorPrefix}: signature mismatch`)
     }
 


### PR DESCRIPTION
# About

Related Issue: #5

# Reference

- https://github.com/slackapi/node-slack-sdk/blob/2a9df19b29951931edee0c0e6f8435bbc1ffb501/packages/events-api/src/http-handler.ts#L53
- https://api.slack.com/authentication/verifying-requests-from-slack#verifying-requests-from-slack-using-signing-secrets__a-recipe-for-security__step-by-step-walk-through-for-validating-a-request